### PR TITLE
#164964483 consume get /messages/unread endpoint

### DIFF
--- a/SERVER/src/Controller/MessageController.js
+++ b/SERVER/src/Controller/MessageController.js
@@ -140,13 +140,14 @@ class MessageController {
       if (inbox.length !== 0) {
         inbox = inbox.map(mail => ({
           id: mail.msg_id,
-          createdOn: new Date(parseInt(mail.date_time, 10)).toLocaleString('en-US', { timeZone: 'UTC' }),
+          createdOn: mail.date_time,
           subject: mail.subject,
           message: mail.message,
           senderId: mail.owner_id,
           receiverId: mail.receiver_id,
           parentMessageId: null,
           status: mail.status,
+          senderEmail: mail.email,
         }));
         res.status(200).json({
           status: 200,

--- a/SERVER/test/message.test.js
+++ b/SERVER/test/message.test.js
@@ -64,14 +64,14 @@ describe('Messages', () => {
       });
     });
 
-    describe('/messages/save', () => {
+    describe('/messages/draft', () => {
       it('should return status 201', (done) => { //  testing for saving message as draft
         obj = {
           subject: 'WOW',
           message: 'you won again',
         };
         chai.request(app)
-          .post('/api/v1/messages/save')
+          .post('/api/v1/messages/draft')
           .set('authorization', authToken)
           .send(obj)
           .end((err, res) => {
@@ -85,7 +85,7 @@ describe('Messages', () => {
           message: 'you won again',
         };
         chai.request(app)
-          .post('/api/v1/messages/save')
+          .post('/api/v1/messages/draft')
           .set('authorization', authToken)
           .send(obj)
           .end((err, res) => {
@@ -106,7 +106,7 @@ describe('Messages', () => {
           message: 'you won again',
         };
         chai.request(app)
-          .post('/api/v1/messages/save')
+          .post('/api/v1/messages/draft')
           .set('authorization', authToken)
           .send(obj)
           .end((err, res) => {
@@ -121,7 +121,7 @@ describe('Messages', () => {
           message: 'you won again',
         };
         chai.request(app)
-          .post('/api/v1/messages/save')
+          .post('/api/v1/messages/draft')
           .set('authorization', authToken)
           .send(obj)
           .end((err, res) => {

--- a/UI/styles/style.css
+++ b/UI/styles/style.css
@@ -359,6 +359,14 @@ button:hover{
     border: #194759 solid .2em;
     cursor: pointer;
 }
+.inbox .toolbar span {
+    display: inline-block;
+    text-align: center;
+    width: 5em;
+}
+.inbox .toolbar span input{
+    top: .15em;
+}
 .inbox .toolbar button:hover{
     opacity: .8;
     font-weight: bold;
@@ -371,6 +379,9 @@ button:hover{
     justify-content: space-between;
     padding: .2em;
     margin: .3em 0;
+}
+.inbox .bottom .inbox-view >div.unread *{
+    font-weight: bold;
 }
 .inbox .bottom .inbox-view >div >*:not(input){
     cursor: pointer;
@@ -393,7 +404,6 @@ button:hover{
     width:15%;
 }
 .inbox .inbox-view >div> p,.inbox .inbox-view .subject, .inbox .inbox-view label{
-    font-weight: bold;
     padding-right: .5em;
     overflow: hidden;
 }


### PR DESCRIPTION
  #### What does this PR do?
-  consume get /messages/unread endpoint with front-end  ui template

#### Description of Task to be completed?
- create radio button to toggle between all, unread, read inbox
- add listeners to the radio buttons
- create a get fecth request to /messages/unread
- populate ui template with fetch response
- ensure only logged in user can make request

#### How should this be manually tested?
- Clone this branch
- Go to SERVER/ folder
- Run ```npm run dev-start```
- Go to UI folder
- Run the ```index.html``` in a web browser
- Sign in and click on ```Inbox```
- Click on ```Unread``` radio button


#### Any background context you want to provide?
- You need node and npm installed
- Run ```npm install``` to install all dependencies 
- You need you Postgres database set

#### What are the relevant pivotal tracker stories?
- #164964483  (https://www.pivotaltracker.com/story/show/164964483)