### PR TITLE
#164967750 consume get /messages/read endpoint

### DIFF
--- a/SERVER/src/Controller/MessageController.js
+++ b/SERVER/src/Controller/MessageController.js
@@ -175,13 +175,14 @@ class MessageController {
       if (inbox.length !== 0) {
         inbox = inbox.map(mail => ({
           id: mail.msg_id,
-          createdOn: new Date(parseInt(mail.date_time, 10)).toLocaleString('en-US', { timeZone: 'UTC' }),
+          createdOn: mail.date_time,
           subject: mail.subject,
           message: mail.message,
           senderId: mail.owner_id,
           receiverId: mail.receiver_id,
           parentMessageId: null,
           status: mail.status,
+          senderEmail: mail.email,
         }));
         res.status(200).json({
           status: 200,

--- a/UI/scripts/script.js
+++ b/UI/scripts/script.js
@@ -256,6 +256,8 @@ window.onload = function ready() {
           postData('GET', '/messages', null, true).then(populateInbox).catch((error) => { alertMessage(error.message); });
         } else if (selectedRadioValue === 'Unread') {
           postData('GET', '/messages/unread', null, true).then(populateInbox).catch((error) => { alertMessage(error.message); });
+        } else if (selectedRadioValue === 'Read') {
+          postData('GET', '/messages/read', null, true).then(populateInbox).catch((error) => { alertMessage(error.message); });
         }
       };
     });
@@ -265,6 +267,8 @@ window.onload = function ready() {
           await postData('GET', '/messages', null, true).then(populateInbox).catch((error) => { alertMessage(error.message); });
         } else if (radioButton.checked && radioButton.value === 'Unread') {
           await postData('GET', '/messages/unread', null, true).then(populateInbox).catch((error) => { alertMessage(error.message); });
+        } else if (radioButton.checked && radioButton.value === 'Read') {
+          postData('GET', '/messages/read', null, true).then(populateInbox).catch((error) => { alertMessage(error.message); });
         }
       });
 


### PR DESCRIPTION
  #### What does this PR do?
-  consume get /messages/read endpoint with front-end  ui template

#### Description of Task to be completed?
- add listeners to the read radio button
- create a get fetch request to /messages/read
- populate ui template with fetch response
- ensure only logged in user can make request

#### How should this be manually tested?
- Clone this branch
- Go to SERVER/ folder
- Run ```npm run dev-start```
- Go to UI folder
- Run the ```index.html``` in a web browser
- Sign in and click on ```Inbox```
- Click on ```Read``` radio button


#### Any background context you want to provide?
- You need node and npm installed
- Run ```npm install``` to install all dependencies 
- You need you Postgres database set

#### What are the relevant pivotal tracker stories?
- #164967750  (https://www.pivotaltracker.com/story/show/164967750)