### PR TITLE
#165095181 consume delete /groups/id endpoint

### DIFF
--- a/SERVER/src/Middleware/Validate.js
+++ b/SERVER/src/Middleware/Validate.js
@@ -401,7 +401,7 @@ class Validate {
               next();
             } else {
               const errorMessage = 'Only group owner can delete a group';
-              Utility.handleError(res, errorMessage, 404);
+              Utility.handleError(res, errorMessage, 400);
             }
           });
         } else {

--- a/UI/scripts/script.js
+++ b/UI/scripts/script.js
@@ -807,10 +807,25 @@ window.onload = function ready() {
 
     /** Delete Group* */
     document.querySelector('.right-group .groups .btn button').onclick = () => {
-      document.querySelectorAll('.right-group .groups input').forEach((element) => {
+      const checkBoxes = document.querySelectorAll('.right-group .groups input');
+      checkBoxes.forEach(async (element) => {
         if (element.checked) {
-          alertMessage('Group(s) Deleted Successfully');
-          element.parentNode.classList.add('hidden');
+          const mailId = element.value;
+          await postData('DELETE', `/groups/${mailId}`, null, true)
+            .then(async (response) => {
+              const resStatus = parseInt(response.status, 10);
+              if (resStatus === 401) {
+                logOut();
+              } else if (resStatus === 204) {
+                document.querySelector('.right-group .groups >div:nth-child(2)').removeChild((element.parentNode));
+                //  alertMessage('Mail(s) Deleted Successfully');
+              } else if (resStatus === 404 || resStatus === 400) {
+                const res = await response.json();
+                throw new Error(res.error);
+              }
+            }).catch((error) => {
+              alertMessage(error.message);
+            });
         }
       });
     };


### PR DESCRIPTION
  #### What does this PR do?
-  consume delete /groups/id endpoint with front-end  ui template

#### Description of Task to be completed?
- create a delete fetch request to /groups/id
- remove deleted group from ui
- handle error response
- ensure only logged in user can make request

#### How should this be manually tested?
- Clone this branch
- Go to SERVER/ folder
- Run ```npm run dev-start```
- Go to UI folder
- Run the ```index.html``` in a web browser
- Sign in and click on ```Groups```
- Select groups(s) and click ```Delete``` button


#### Any background context you want to provide?
- You need node and npm installed
- Run ```npm install``` to install all dependencies 
- You need Postgres database set

#### What are the relevant pivotal tracker stories?
- #165095181  (https://www.pivotaltracker.com/story/show/165095181)